### PR TITLE
Add aws endpoint option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,6 +34,7 @@ bw_network_name: bw_network
 pg4bw_aws_key: 'some_aws_access_key'
 pg4bw_aws_secret: 'some_aws_secret_key'
 pg4bw_aws_region: 'some_aws_region'
+pg4bw_aws_endpoint: "s3.{{ pg4bw_aws_region }}.amazonaws.com"
 pg4bw_s3_bucket: 's3://aws_s3_bucket_name'
 
 # Telegram notification variables

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,6 +52,7 @@
             ARCHIVE_TIMEOUT: 3600
             AWS_ACCESS_KEY_ID: "{{ pg4bw_aws_key }}"
             AWS_REGION: "{{ pg4bw_aws_region }}"
+            AWS_ENDPOINT: "{{ pg4bw_aws_endpoint }}"
             AWS_SECRET_ACCESS_KEY: "{{ pg4bw_aws_secret }}"
             WALG_S3_PREFIX: "{{ pg4bw_s3_bucket }}"
             PGDATABASE: vaultwarden
@@ -96,8 +97,7 @@
             - DATABASE_URL=postgresql://{{ pg4bw_vaultwarden_user }}:{{ pg4bw_vaultwarden_password }}@{{ pg4bw_container_name }}:5432/vaultwarden
           container_name: "{{ bw_container_name }}"
           depends_on:
-            bitwarden-db:
-              condition: service_healthy
+            - bitwarden-db
       networks:
         default:
           external:


### PR DESCRIPTION
To allow working with non-AWS S3 endpoints e.g. private ones like Ceph of Minio installation; or public ones like Selectel, add an option pg4bw_aws_endpoint. Default value is set to AWS one, so it backward compatible.

Also fix compose service definition - in newer versions there is no way to setup depends_on as a hashmap, it has to be an array instead.